### PR TITLE
Update __init__.py

### DIFF
--- a/src/bencode/__init__.py
+++ b/src/bencode/__init__.py
@@ -137,7 +137,7 @@ def encode_dict(x):
     result.append(ord("d"))
 
     for k, v in sorted(x.items()):
-        result.extend(encode_string(str(k)))
+        result.extend(encode_func[type(k)](k))
         result.extend(encode_func[type(v)](v))
 
     result.append(ord("e"))


### PR DESCRIPTION
Fix: a dict with a key of type that cannot be converted via `str()` cannot be encoded correctly.
e.g. bytes cannot be converted via `str()`, so I change `result.extend(encode_string(str(k)))` into `result.extend(encode_func[type(k)](k))`.